### PR TITLE
Fix Rex::Encoder::XDR.decode_int! to properly handle short data

### DIFF
--- a/lib/rex/encoder/xdr.rb
+++ b/lib/rex/encoder/xdr.rb
@@ -16,8 +16,9 @@ module XDR
   end
 
   def XDR.decode_int!(data)
-      return data.slice!(0..3).unpack('N')[0] if data
-      data = 0
+    raise ArgumentError, 'XDR: No Integer data to decode' unless data
+    raise ArgumentError, "XDR: Too little data to decode (#{data.size})" if data.size < 4
+    return data.slice!(0..3).unpack('N')[0]
   end
 
   def XDR.encode_lchar(char)

--- a/spec/lib/rex/encoder/xdr_spec.rb
+++ b/spec/lib/rex/encoder/xdr_spec.rb
@@ -23,16 +23,16 @@ describe Rex::Encoder::XDR do
 
     context "when data is nil" do
       let(:data) { nil }
-      it "returns 0" do
-        is_expected.to be(0)
+      it "raises an error" do
+        expect { decoded_int }.to raise_error(ArgumentError)
       end
     end
 
     context "when data is empty" do
       let(:data) { '' }
 
-      it "returns nil" do
-        is_expected.to be_nil
+      it "raises an error" do
+        expect { decoded_int }.to raise_error(ArgumentError)
       end
     end
 
@@ -88,7 +88,7 @@ describe Rex::Encoder::XDR do
       let(:data) { "\x41" }
 
       it "raises an error" do
-        expect { decoded_lchar }.to raise_error(NoMethodError)
+        expect { decoded_lchar }.to raise_error(ArgumentError)
       end
     end
   end
@@ -205,16 +205,16 @@ describe Rex::Encoder::XDR do
       context "and no values" do
         let(:data) { "\x00\x00\x00\x02" }
 
-        it "returns an Array filled with nils" do
-          expect(described_class.decode_varray!(data) { |s| described_class.decode_int!(s) }).to eq([nil, nil])
+        it "raises an error" do
+          expect { described_class.decode_varray!(data) { |s| described_class.decode_int!(s) } }.to raise_error(ArgumentError)
         end
       end
 
       context "longer than available values" do
         let(:data) { "\x00\x00\x00\x02\x00\x00\x00\x41" }
 
-        it "returns Array padded with nils" do
-          expect(described_class.decode_varray!(data) { |s| described_class.decode_int!(s) }).to eq([0x41, nil])
+        it "raises an error" do
+          expect { described_class.decode_varray!(data) { |s| described_class.decode_int!(s) } }.to raise_error(ArgumentError)
         end
       end
     end


### PR DESCRIPTION
This fixes the issues I raised in #3767, namely that `decode_int!` was improperly implemented and was written to handle short XDR data, which is invalid -- XDR must always be a multiple of 4 bytes.  I also corrected some other areas of Rex::Encoder::XDR that were incorrectly relying on this functionality.  Fortunately, this code is used only by a handful of modules:

```
modules/exploits/solaris/sunrpc/sadmind_exec.rb
modules/auxiliary/scanner/nfs/nfsmount.rb
modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
```

I don't have a machine that is vulnerable to the first or last issues, but I have a solaris 9 host that should get picked up by the middle two.  After this patch, those two modules still work identically.
