### PR TITLE
Add support for ConnectTimeout and RecvTimeout

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -52,7 +52,9 @@ module Exploit::Remote::HttpClient
         OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
-        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION'])
+        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
+        OptInt.new('ConnectTimeout', [ true, 'The amount of time in seconds to establish the connection', 5 ]),
+        OptInt.new('RecvTimeout', [ true, 'The amount of time to wait for server response before closing the connection', 5 ])
       ], self.class
     )
 
@@ -194,7 +196,9 @@ module Exploit::Remote::HttpClient
       'SendSPN'                => datastore['NTLM::SendSPN'],
       'UseLMKey'               => datastore['NTLM::UseLMKey'],
       'domain'                 => datastore['DOMAIN'],
-      'DigestAuthIIS'          => datastore['DigestAuthIIS']
+      'DigestAuthIIS'          => datastore['DigestAuthIIS'],
+      'connect_timeout'        => datastore['ConnectTimeout'],
+      'receive_timeout'        => datastore['RecvTimeout']
     )
 
     # If this connection is global, persist it
@@ -254,7 +258,9 @@ module Exploit::Remote::HttpClient
       ntlm_send_spn:                 datastore['NTLM::SendSPN'],
       ntlm_use_lm_key:               datastore['NTLM::UseLMKey'],
       ntlm_domain:                   datastore['DOMAIN'],
-      digest_auth_iis:               datastore['DigestAuthIIS']
+      digest_auth_iis:               datastore['DigestAuthIIS'],
+      connect_timeout:               datastore['ConnectTimeout'],
+      receive_timeout:               datastore['receive_timeout']
     }.merge(conf)
   end
 
@@ -306,11 +312,15 @@ module Exploit::Remote::HttpClient
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
-  def send_request_raw(opts={}, timeout = 20)
+  def send_request_raw(opts={})
     begin
       c = connect(opts)
-      r = c.request_raw(opts)
-      c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      opts = opts.merge({
+        'request'         => c.request_raw(opts),
+        'connect_timeout' => opts['connect_timeout'] || datastore['ConnectTimeout'],
+        'recv_timeout'    => opts['recv_timeout'] || datastore['RecvTimeout']
+      })
+      c.send_recv(opts)
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end
@@ -322,11 +332,15 @@ module Exploit::Remote::HttpClient
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
   #
-  def send_request_cgi(opts={}, timeout = 20)
+  def send_request_cgi(opts={})
     begin
       c = connect(opts)
-      r = c.request_cgi(opts)
-      c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      opts = opts.merge({
+        'request'         => c.request_cgi(opts),
+        'connect_timeout' => opts['connect_timeout'] || datastore['ConnectTimeout'],
+        'recv_timeout'    => opts['recv_timeout'] || datastore['RecvTimeout']
+      })
+      c.send_recv(opts)
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end
@@ -340,8 +354,8 @@ module Exploit::Remote::HttpClient
   # @note The +opts+ will be updated to the updated location and +opts['redirect_uri']+
   #   will contain the full URI.
   #
-  def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
-    res = send_request_cgi(opts, timeout)
+  def send_request_cgi!(opts={}, redirect_depth = 1)
+    res = send_request_cgi(opts)
     return res unless res && res.redirect? && redirect_depth > 0
 
     redirect_depth -= 1
@@ -360,7 +374,7 @@ module Exploit::Remote::HttpClient
       opts['ssl'] = false
     end
 
-    send_request_cgi!(opts, timeout, redirect_depth)
+    send_request_cgi!(opts, redirect_depth)
   end
 
   #
@@ -487,6 +501,20 @@ module Exploit::Remote::HttpClient
     datastore['Proxies']
   end
 
+  #
+  # Returns the response receiving timeout
+  #
+  def recv_timeout
+    datastore['RecvTimeout']
+  end
+
+
+  #
+  # Returns the connection timeout
+  #
+  def connect_timeout
+    datastore['ConnectTimeout']
+  end
 
   #
   # Lookup HTTP fingerprints from the database that match the current

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -267,8 +267,8 @@ class Client
   #
   # @param res [Response] the HTTP Response object
   # @param opts [Hash] the options used to generate the original HTTP request
-  # @param connect_timeout [Fixnum]
-  # @param recv_timeout [Fixnum]
+  # @param connect_timeout [Fixnum] Default: 5
+  # @param recv_timeout [Fixnum] Default: 5
   # @param persist [Boolean] whether or not to persist the TCP connection (pipelining)
   #
   # @return [Response] the last valid HTTP response object we received
@@ -294,7 +294,7 @@ class Client
       opts['headers'] ||= {}
       opts['headers']['Authorization'] = basic_auth_header(opts['username'],opts['password'] )
       req = request_cgi(opts)
-      res = _send_recv(req, connect_timeout, recv_timeout ,persist)
+      res = _send_recv(opts.merge({'request'=>req}))
       return res
     elsif  supported_auths.include? "Digest"
       temp_response = digest_auth(opts)
@@ -360,7 +360,7 @@ class Client
       r = request_cgi(opts.merge({
           'uri' => path,
           'method' => method }))
-      resp = _send_recv(r, connect_timeout, recv_timeout)
+      resp = _send_recv(opts.merge('request'=>r))
       unless resp.kind_of? Rex::Proto::Http::Response
         return nil
       end
@@ -457,7 +457,7 @@ class Client
       'uri' => path,
       'method' => method,
       'headers' => headers }))
-    resp = _send_recv(r, connect_timeout, recv_timeout, true)
+    resp = _send_recv(opts.merge({'request'=>r, 'persistent'=>true}))
     unless resp.kind_of? Rex::Proto::Http::Response
       return nil
     end
@@ -516,7 +516,7 @@ class Client
       # First request to get the challenge
       opts['headers']['Authorization'] = ntlm_message_1
       r = request_cgi(opts)
-      resp = _send_recv(r, connect_timeout, recv_timeout)
+      resp = _send_recv(opts.merge({'request'=>r}))
       unless resp.kind_of? Rex::Proto::Http::Response
         return nil
       end
@@ -569,7 +569,7 @@ class Client
       # Send the response
       opts['headers']['Authorization'] = "#{provider}#{ntlm_message_3}"
       r = request_cgi(opts)
-      resp = _send_recv(r, connect_timeout, recv_timeout, true)
+      resp = _send_recv(opts.merge({'request'=>r, 'persistent'=>true}))
       unless resp.kind_of? Rex::Proto::Http::Response
         return nil
       end

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -222,7 +222,7 @@ class Client
 
     res = _send_recv(opts)
     if res and res.code == 401 and res.headers['WWW-Authenticate']
-      res = send_auth(opts)
+      res = send_auth(opts.merge({'response'=>res}))
     end
     res
   end


### PR DESCRIPTION
This only modifies msf and rex, no modules are modified. If these changes are okay, then we can move on to modules.
# Verification Steps
- [ ] Save this file as auxiliary/gather/test.rb: https://gist.github.com/wchen-r7/164c40de6cc8a01e5677
## Test connection timeout
- [ ] Set up an HTTP server (I did it with IIS)
- [ ] Block that HTTP port (firewall)
- [ ] In test.rb, make sure the `try_user_defined_timeouts` call is uncommented.
- [ ] In test.rb, make sure the `try_mod_defined_timeouts` cals is commented out.
- [ ] Start msfconsole
- [ ] `use auxiliary/gather/test`
- [ ] `set rhost [IP]`
- [ ] `set ConnectTimeout 3`
- [ ] `run`
- [ ] You should see that the Time spent message is about 3 seconds. For example:

```
msf auxiliary(http_test) > run

[*] Your connection timeout is: 3
[*] Your response timeout is  : 5
[*] Sending request
[-] Rex::ConnectionTimeout The connection timed out (192.168.1.169:8181).
[*] Time spent: 3.062065
[*] Your response object is: NilClass
[*] Auxiliary module execution completed
```
## Test response timeout
- [ ] Set up a netcat server as a fake HTTP server: `nc -l 8181`
- [ ] Start msfconsole
- [ ] `use auxiliary/gather/test`
- [ ] `set rhost [IP]`
- [ ] `set RecvTimeout 1`
- [ ] `run`
- [ ] You should see that the Time spent message is about 1 second. For example:

```
msf auxiliary(http_test) > run

[*] Your connection timeout is: 3
[*] Your response timeout is  : 1
[*] Sending request
[*] Time spent: 1.227949
[*] Your response object is: NilClass
[*] Auxiliary module execution completed
```
## Test HTTP authentication
- [ ] Preferably IIS (I did it on a Windows 8.1 + IIS box)
- [ ] Make sure your IIS supports: Basic auth and Windows auth.
- [ ] Create a folder called "auth" in C:\Inetpub\wwwroot\
- [ ] Open IIS Manager
- [ ] Find the "auth" folder under Default Web Site, click on that.
- [ ] On the right, click on Authentication
- [ ] Disable Anonymous Authentication
- [ ] Enable Windows Authentication
- [ ] Open a browser, and make sure http://[server ip]/auth/ is asking you to auth
- [ ] Start msfconsole
- [ ] `use auxiliary/gather/test`
- [ ] `use rhost [ip]`
- [ ] `set targeturi /auth/`
- [ ] `set username [valid username]`
- [ ] `set password [bad password]`
- [ ] `run`
- [ ] You should get a 401
- [ ] Try again with a valid password
- [ ] You should NOT get a 401.
- [ ] Go back to IIS Manager: disable Windows Auth, and enable Basic Auth.
- [ ] Try the test module again against Basic Auth.
